### PR TITLE
Fix build by removing cross-framework reference

### DIFF
--- a/src/Presentation/Presentation.csproj
+++ b/src/Presentation/Presentation.csproj
@@ -11,9 +11,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="3.4.0" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Application\Application.csproj" />
-  </ItemGroup>
 
 </Project>
 


### PR DESCRIPTION
## Summary
- remove the Application project reference from the Presentation project because referencing `Microsoft.AspNetCore.App` breaks the WASM build

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build --configuration Release`
- `dotnet test --collect:"XPlat Code Coverage"`
- `coverlet ./src/Infrastructure/bin/Release/net8.0/Infrastructure.dll --target "dotnet" --targetargs "test --no-build --configuration Release" --threshold 70`
- `grep -r 'Console.WriteLine' src/`

------
https://chatgpt.com/codex/tasks/task_e_68584f90f5908320bacf3aeb979fd743