### PR TITLE
Update configuration to local.settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@
 
 ローカル環境では Azure リソースを作成せず、`npm run dev` や `func start` でアプリを
 起動し、データベースには Cosmos DB Emulator を利用します。
+
+`local.settings.sample.json` を `local.settings.json` にコピーし、
+`GooglePlacesApiKey` と `CosmosDbConnection` を設定してから実行してください。

--- a/local.settings.sample.json
+++ b/local.settings.sample.json
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "GooglePlacesApiKey": "YOUR_GOOGLE_PLACES_API_KEY",
+    "CosmosDbConnection": "YOUR_COSMOS_DB_CONNECTION_STRING",
+    "COSMOS_DATABASE": "astro-db"
+  }
+}

--- a/src/Application/Functions/AdminFunctions.cs
+++ b/src/Application/Functions/AdminFunctions.cs
@@ -16,7 +16,7 @@ public class AdminFunctions
     public AdminFunctions(ILoggerFactory loggerFactory)
     {
         _logger = loggerFactory.CreateLogger<AdminFunctions>();
-        _connectionString = Environment.GetEnvironmentVariable("COSMOS_CONNECTION") ?? string.Empty;
+        _connectionString = Environment.GetEnvironmentVariable("CosmosDbConnection") ?? string.Empty;
         _databaseName = Environment.GetEnvironmentVariable("COSMOS_DATABASE") ?? "astro-db";
     }
 

--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -16,8 +16,8 @@ if (string.Equals(environment, "Development", StringComparison.OrdinalIgnoreCase
 {
     try
     {
-        var sourcePath = Path.Combine("..", "..", "#config", "appsettings.Development.json");
-        var destPath = Path.Combine(Environment.CurrentDirectory, "appsettings.Development.json");
+        var sourcePath = Path.Combine("..", "..", "#config", "local.settings.json");
+        var destPath = Path.Combine(Environment.CurrentDirectory, "local.settings.json");
         File.Copy(sourcePath, destPath, true);
     }
     catch (Exception ex)
@@ -34,7 +34,7 @@ builder.Services.AddHttpClient();
 
 builder.Services.AddSingleton<ILogRepository>(_ =>
     new CosmosLogRepository(
-        Environment.GetEnvironmentVariable("COSMOS_CONNECTION") ?? string.Empty,
+        Environment.GetEnvironmentVariable("CosmosDbConnection") ?? string.Empty,
         Environment.GetEnvironmentVariable("COSMOS_DATABASE") ?? "astro-db"));
 
 builder.Services.AddSingleton<Application.Services.BirthplaceSearchService>();

--- a/src/Application/Services/BirthplaceSearchService.cs
+++ b/src/Application/Services/BirthplaceSearchService.cs
@@ -18,7 +18,7 @@ public class BirthplaceSearchService
         _httpClient = httpClient;
         _logRepository = logRepository;
         _logger = logger;
-        _apiKey = Environment.GetEnvironmentVariable("PLACES_API_KEY") ?? string.Empty;
+        _apiKey = Environment.GetEnvironmentVariable("GooglePlacesApiKey") ?? string.Empty;
     }
 
     public async Task<SearchResults> SearchAsync(string query, string sessionId)


### PR DESCRIPTION
## Summary
- read GooglePlacesApiKey and CosmosDbConnection from environment variables
- copy `#config/local.settings.json` at startup instead of appsettings.Development.json
- document usage of local.settings.sample.json
- add example `local.settings.sample.json`

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total` *(fails: The total line coverage is below the specified 70)*
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total` *(fails: The total line coverage is below the specified 70)*

------
https://chatgpt.com/codex/tasks/task_e_6858dded92e48320bef2564cfdc6d6c7