### PR TITLE
Change test data endpoints

### DIFF
--- a/src/Application/Functions/AdminFunctions.cs
+++ b/src/Application/Functions/AdminFunctions.cs
@@ -21,7 +21,7 @@ public class AdminFunctions
     }
 
     [Function("InitializeDatabase")]
-    public async Task<HttpResponseData> InitializeDatabase([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "admin/initialize")] HttpRequestData req)
+    public async Task<HttpResponseData> InitializeDatabase([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "test-data/initialize")] HttpRequestData req)
     {
         try
         {
@@ -41,7 +41,7 @@ public class AdminFunctions
     }
 
     [Function("SeedTestData")]
-    public async Task<HttpResponseData> SeedTestData([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "admin/seed")] HttpRequestData req)
+    public async Task<HttpResponseData> SeedTestData([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "test-data/seed")] HttpRequestData req)
     {
         try
         {


### PR DESCRIPTION
## Summary
- change Cosmos DB initialization and seed routes from `/admin` to `/test-data`

## Testing
- `dotnet format --verify-no-changes -v diag`
- `dotnet build astro-form2.sln -c Release`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total` *(fails: The total line coverage is below the specified 70)*
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total` *(fails: The total line coverage is below the specified 70)*

------
https://chatgpt.com/codex/tasks/task_e_685906f56d98832099796ef370e2f9ee