### PR TITLE
Set Search as home page

### DIFF
--- a/src/Presentation/Layout/NavMenu.razor
+++ b/src/Presentation/Layout/NavMenu.razor
@@ -1,9 +1,6 @@
 ﻿<FluentNav aria-label="Main navigation">
     <FluentNavMenu>
         <FluentNavMenuItem href="" Match="NavLinkMatch.All">
-            Home
-        </FluentNavMenuItem>
-        <FluentNavMenuItem href="search">
             Search
         </FluentNavMenuItem>
     </FluentNavMenu>

--- a/src/Presentation/Pages/Home.razor
+++ b/src/Presentation/Pages/Home.razor
@@ -1,7 +1,0 @@
-﻿@page "/"
-
-<PageTitle>Home</PageTitle>
-
-<h1>Hello, world!</h1>
-
-Welcome to your new app.

--- a/src/Presentation/Pages/Search.razor
+++ b/src/Presentation/Pages/Search.razor
@@ -1,4 +1,4 @@
-@page "/search"
+@page "/"
 
 <Header />
 

--- a/src/Test/Domain/DomainModelTests.cs
+++ b/src/Test/Domain/DomainModelTests.cs
@@ -1,0 +1,41 @@
+using System;
+using Domain.Models;
+using Xunit;
+
+public class DomainModelTests
+{
+    [Fact]
+    public void AccessLog_StoresValues()
+    {
+        var now = DateTime.UtcNow;
+        var log = new AccessLog("id", "sid", now);
+        Assert.Equal("id", log.Id);
+        Assert.Equal("sid", log.SessionId);
+        Assert.Equal(now, log.AccessedAt);
+    }
+
+    [Fact]
+    public void ActionLog_StoresValues()
+    {
+        var now = DateTime.UtcNow;
+        var log = new ActionLog("id", "sid", "act", now);
+        Assert.Equal("id", log.Id);
+        Assert.Equal("sid", log.SessionId);
+        Assert.Equal("act", log.ActionName);
+        Assert.Equal(now, log.ActionedAt);
+    }
+
+    [Fact]
+    public void SearchResultLog_StoresValues()
+    {
+        var now = DateTime.UtcNow;
+        var log = new SearchResultLog("id", "sid", "pid", "query", 1.2m, 3.4m, now);
+        Assert.Equal("id", log.Id);
+        Assert.Equal("sid", log.SessionId);
+        Assert.Equal("pid", log.PlaceId);
+        Assert.Equal("query", log.Query);
+        Assert.Equal(1.2m, log.Lat);
+        Assert.Equal(3.4m, log.Lng);
+        Assert.Equal(now, log.SearchedAt);
+    }
+}


### PR DESCRIPTION
## Summary
- remove unused Home page
- make Search page the default route
- update navigation to point to Search
- add domain model unit tests
- extend BirthplaceSearchService tests

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total --include "[Application]Application.Services*"`
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total --include "[Domain]*"`


------
https://chatgpt.com/codex/tasks/task_e_685907570a74832081764073a2785ac3