### PR TITLE
Update local settings path

### DIFF
--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -16,7 +16,7 @@ if (string.Equals(environment, "Development", StringComparison.OrdinalIgnoreCase
 {
     try
     {
-        var sourcePath = Path.Combine("..", "..", "#config", "local.settings.json");
+        var sourcePath = Path.Combine("..", "..", "config", "local.settings.json");
         var destPath = Path.Combine(Environment.CurrentDirectory, "local.settings.json");
         File.Copy(sourcePath, destPath, true);
     }


### PR DESCRIPTION
## Summary
- fix local settings copy path to use `/config`

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total`
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total`


------
https://chatgpt.com/codex/tasks/task_e_68590f0ed25483209f733c98c6ad34a5