### PR TITLE
Add Japanese language parameter to map searches

### DIFF
--- a/src/Application/Services/BirthplaceSearchService.cs
+++ b/src/Application/Services/BirthplaceSearchService.cs
@@ -31,7 +31,7 @@ public class BirthplaceSearchService
             await _logRepository.AddActionLogAsync(log);
         }
 
-        var url = $"https://maps.googleapis.com/maps/api/place/autocomplete/json?input={Uri.EscapeDataString(query)}&key={_apiKey}";
+        var url = $"https://maps.googleapis.com/maps/api/place/autocomplete/json?input={Uri.EscapeDataString(query)}&language=ja&key={_apiKey}";
         var httpResp = await _httpClient.GetAsync(url);
         httpResp.EnsureSuccessStatusCode();
         var json = await httpResp.Content.ReadAsStringAsync();
@@ -53,7 +53,7 @@ public class BirthplaceSearchService
     {
         if (string.IsNullOrWhiteSpace(placeId)) throw new ArgumentException("placeId is required", nameof(placeId));
 
-        var url = $"https://maps.googleapis.com/maps/api/place/details/json?place_id={Uri.EscapeDataString(placeId)}&key={_apiKey}";
+        var url = $"https://maps.googleapis.com/maps/api/place/details/json?place_id={Uri.EscapeDataString(placeId)}&language=ja&key={_apiKey}";
         var httpResp = await _httpClient.GetAsync(url);
         httpResp.EnsureSuccessStatusCode();
         var json = await httpResp.Content.ReadAsStringAsync();

--- a/src/Test/Application/BirthplaceSearchServiceTest.cs
+++ b/src/Test/Application/BirthplaceSearchServiceTest.cs
@@ -105,4 +105,43 @@ public class BirthplaceSearchServiceTest
         var service = new BirthplaceSearchService(client, repo, NullLogger<BirthplaceSearchService>.Instance);
         await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetPlaceDetailsAsync("1", "tokyo", "sid"));
     }
+
+    [Fact]
+    public async Task SearchAsync_Uses_Japanese_Language()
+    {
+        string? requestedUrl = null;
+        var handler = new FakeHttpHandler(req =>
+        {
+            requestedUrl = req.RequestUri!.ToString();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"predictions\":[]}")
+            };
+        });
+        var repo = new FakeLogRepository();
+        var client = new HttpClient(handler);
+        var service = new BirthplaceSearchService(client, repo, NullLogger<BirthplaceSearchService>.Instance);
+        await service.SearchAsync("tokyo", string.Empty);
+        Assert.Contains("language=ja", requestedUrl);
+    }
+
+    [Fact]
+    public async Task GetPlaceDetailsAsync_Uses_Japanese_Language()
+    {
+        string? requestedUrl = null;
+        var json = "{\"status\":\"OK\",\"result\":{\"place_id\":\"1\",\"name\":\"Tokyo\",\"formatted_address\":\"Tokyo\",\"geometry\":{\"location\":{\"lat\":1,\"lng\":2}},\"url\":\"u\"}}";
+        var handler = new FakeHttpHandler(req =>
+        {
+            requestedUrl = req.RequestUri!.ToString();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json)
+            };
+        });
+        var repo = new FakeLogRepository();
+        var client = new HttpClient(handler);
+        var service = new BirthplaceSearchService(client, repo, NullLogger<BirthplaceSearchService>.Instance);
+        await service.GetPlaceDetailsAsync("1", "tokyo", string.Empty);
+        Assert.Contains("language=ja", requestedUrl);
+    }
 }


### PR DESCRIPTION
## Summary
- request Japanese results from Google Places API
- test that map search and detail requests include language parameter

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total`
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total`


------
https://chatgpt.com/codex/tasks/task_e_685943d334608320b6133e275384aa09