### PR TITLE
Implement Cosmos DB auto-initializer

### DIFF
--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -1,2 +1,3 @@
 # 日本語で記載してください
 
+- Cosmos DB は `/admin/initialize` API で手動作成する設計だったが、起動時にスキーマを自動作成する HostedService `CosmosDbInitializer` を追加

--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -39,4 +39,6 @@ builder.Services.AddSingleton<ILogRepository>(_ =>
 
 builder.Services.AddSingleton<Application.Services.BirthplaceSearchService>();
 
+builder.Services.AddHostedService<CosmosDbInitializer>();
+
 builder.Build().Run();

--- a/src/Infrastructure/CosmosDbInitializer.cs
+++ b/src/Infrastructure/CosmosDbInitializer.cs
@@ -1,0 +1,28 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Hosting;
+
+namespace Infrastructure;
+
+public class CosmosDbInitializer : IHostedService
+{
+    private readonly string _connectionString;
+    private readonly string _databaseName;
+
+    public CosmosDbInitializer()
+    {
+        _connectionString = Environment.GetEnvironmentVariable("CosmosDbConnection") ?? string.Empty;
+        _databaseName = Environment.GetEnvironmentVariable("COSMOS_DATABASE") ?? "astro-db";
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(_connectionString)) return;
+        var client = new CosmosClient(_connectionString);
+        var database = await client.CreateDatabaseIfNotExistsAsync(_databaseName, cancellationToken: cancellationToken);
+        await database.Database.CreateContainerIfNotExistsAsync("access", "/session_id", cancellationToken: cancellationToken);
+        await database.Database.CreateContainerIfNotExistsAsync("actions", "/session_id", cancellationToken: cancellationToken);
+        await database.Database.CreateContainerIfNotExistsAsync("search_result", "/session_id", cancellationToken: cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}


### PR DESCRIPTION
## Summary
- ensure Cosmos DB containers exist using `CosmosDbInitializer` hosted service
- register initializer in the Azure Functions host
- document difference with the specification in `ai-review.md`

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total`
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total`


------
https://chatgpt.com/codex/tasks/task_e_6859efe4a3e083209f8a7408ab989f60