### PR TITLE
Fix dynamic error in Next.js dev server

### DIFF
--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -2,3 +2,6 @@
 
 - Cosmos DB は `/admin/initialize` API で手動作成する設計だったが、起動時にスキーマを自動作成する HostedService `CosmosDbInitializer` を追加
 - フロントエンドを Blazor から Next.js (React) に変更
+- 仕様では `next export` を前提とした静的サイトとして構築する記載があるが、実装
+ では API への動的アクセスが必要なため `next.config.mjs` の `output: 'export'`
+ 設定を削除し、動的レンダリングに対応した

--- a/src/Presentation/next.config.mjs
+++ b/src/Presentation/next.config.mjs
@@ -1,6 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  output: 'export'
-};
+const nextConfig = {};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- remove `output: 'export'` from the Next.js config so the app runs in dynamic mode
- note discrepancy with spec in `docs/ai-review.md`

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total` *(fails: The total line coverage is below the specified 70)*
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total` *(fails: The total line coverage is below the specified 70)*

------
https://chatgpt.com/codex/tasks/task_e_685abff6c4448320b903a12642f97f25