### PR TITLE
Fix local frontend API routing

### DIFF
--- a/src/Presentation/next.config.mjs
+++ b/src/Presentation/next.config.mjs
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async rewrites() {
+    const apiUrl = process.env.API_URL || 'http://localhost:7071';
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${apiUrl}/api/:path*`,
+      },
+    ];
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- adjust local Next.js configuration to proxy `/api` requests to the Functions port

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `dotnet test ./src/Test/Application/Application.Tests.csproj -c Release`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total` *(fails: The total line coverage is below the specified 70)*
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total` *(fails: The total line coverage is below the specified 70)*

------
https://chatgpt.com/codex/tasks/task_e_685ac3f5919483208f33958e688ebcba