### PR TITLE
Fix coverlet coverage evaluation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ dotnet test astro-form2.sln --collect:"XPlat Code Coverage"
 # アプリケーション層（70%以上必要）
 coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll \
   --target "dotnet" \
-  --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release" \
+  --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release --no-build" \
   --format cobertura \
   --output ./TestResults/coverage-application.xml \
   --threshold 70 \
@@ -20,7 +20,7 @@ coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll \
 # ドメイン層（70%以上必要）
 coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll \
   --target "dotnet" \
-  --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release" \
+  --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release --no-build" \
   --format cobertura \
   --output ./TestResults/coverage-domain.xml \
   --threshold 70 \

--- a/specification/test-policy.yaml
+++ b/specification/test-policy.yaml
@@ -8,7 +8,7 @@ ci:
     dotnet_format: `dotnet format --verify-no-changes` によりコード整形ルールの逸脱を検出
     dotnet_build: `dotnet build --configuration Release` によるビルド
     dotnet_test: `dotnet test --collect:\"XPlat Code Coverage\"` による単体テスト＋カバレッジ取得
-    coverlet: `coverlet` によるカバレッジ評価（70%以上で成功）
+    coverlet: `coverlet` で `--no-build` を付与しカバレッジを評価（70%以上で成功）
   rules:
     restrict_console: Console.WriteLine は禁止し、Serilog によるロギングに統一。`CA1303` 等のルールがエラーとして扱われます
     editor_config: `.editorconfig` に違反するコードは reject されます


### PR DESCRIPTION
## Summary
- add `--no-build` option to coverlet commands in `AGENTS.md`
- clarify test-policy about using `--no-build`

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total`
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total`


------
https://chatgpt.com/codex/tasks/task_e_685ac54fc9cc8320ad8ac000333c6b14