### PR TITLE
Fix frontend parsing for API responses

### DIFF
--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -3,5 +3,8 @@
 - Cosmos DB は `/admin/initialize` API で手動作成する設計だったが、起動時にスキーマを自動作成する HostedService `CosmosDbInitializer` を追加
 - フロントエンドを Blazor から Next.js (React) に変更
 - 仕様では `next export` を前提とした静的サイトとして構築する記載があるが、実装
- では API への動的アクセスが必要なため `next.config.mjs` の `output: 'export'`
- 設定を削除し、動的レンダリングに対応した
+  では API への動的アクセスが必要なため `next.config.mjs` の `output: 'export'`
+  設定を削除し、動的レンダリングに対応した
+- `SearchResults` と `PlaceDetails` の JSON プロパティ名は実装では camelCase
+  (`placeId`, `mapUrl` 等) だが、仕様書では snake_case (`place_id`, `map_url` 等)
+  と記載されている

--- a/src/Presentation/components/PlaceSearchForm.tsx
+++ b/src/Presentation/components/PlaceSearchForm.tsx
@@ -34,7 +34,17 @@ export default function PlaceSearchForm({ onSelected }: Props) {
     const resp = await fetch(`/api/map?query=${encodeURIComponent(q)}`);
     if (resp.ok) {
       const data = await resp.json();
-      setSuggestions(data.results);
+      const results = data.results ?? data.Results ?? [];
+      if (Array.isArray(results)) {
+        const normalized = results.map((r: any) => ({
+          place_id: r.place_id ?? r.placeId,
+          name: r.name,
+          description: r.description,
+        }));
+        setSuggestions(normalized);
+      } else {
+        setSuggestions([]);
+      }
     }
   }
 
@@ -43,8 +53,16 @@ export default function PlaceSearchForm({ onSelected }: Props) {
     setSuggestions([]);
     const resp = await fetch(`/api/map/${item.place_id}`);
     if (resp.ok) {
-      const detail: PlaceDetails = await resp.json();
-      onSelected(detail);
+      const detail = await resp.json();
+      const normalized: PlaceDetails = {
+        place_id: detail.place_id ?? detail.placeId,
+        name: detail.name,
+        address: detail.address,
+        lat: detail.lat,
+        lng: detail.lng,
+        map_url: detail.map_url ?? detail.mapUrl,
+      };
+      onSelected(normalized);
     }
   }
 


### PR DESCRIPTION
## Summary
- normalize property names returned from API to avoid undefined errors
- document deviation about camelCase JSON properties

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total` *(fails: The total line coverage is below the specified 70)*
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total` *(fails: The total line coverage is below the specified 70)*

------
https://chatgpt.com/codex/tasks/task_e_685ac5debebc83209f3cdfe8bec9ef1b