### PR TITLE
Fix access log request format

### DIFF
--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -8,3 +8,6 @@
 - `SearchResults` と `PlaceDetails` の JSON プロパティ名は実装では camelCase
   (`placeId`, `mapUrl` 等) だが、仕様書では snake_case (`place_id`, `map_url` 等)
   と記載されている
+- `AccessLog` 送信時の JSON プロパティも実装では `id`, `sessionId`, `accessedAt`
+  を要求するが、仕様書では `session_id`, `accessed_at` のみを送信すると記載
+  されている

--- a/src/Presentation/app/search/page.tsx
+++ b/src/Presentation/app/search/page.tsx
@@ -4,8 +4,9 @@ import PlaceSearchForm from '../../components/PlaceSearchForm';
 import PlaceSearchResult from '../../components/PlaceSearchResult';
 
 interface AccessLog {
-  session_id: string;
-  accessed_at: string;
+  id: string;
+  sessionId: string;
+  accessedAt: string;
 }
 
 interface PlaceDetails {
@@ -21,7 +22,11 @@ export default function SearchPage() {
   const [result, setResult] = useState<PlaceDetails | undefined>();
 
   useEffect(() => {
-    const log: AccessLog = { session_id: crypto.randomUUID(), accessed_at: new Date().toISOString() };
+    const log: AccessLog = {
+      id: crypto.randomUUID(),
+      sessionId: crypto.randomUUID(),
+      accessedAt: new Date().toISOString(),
+    };
     fetch('/api/log/access', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(log) });
     fetch('/api/test-data/initialize', { method: 'POST' }).catch(() => {});
     fetch('/api/test-data/seed', { method: 'POST' }).catch(() => {});


### PR DESCRIPTION
## Summary
- adjust log payload format to include `id`, `sessionId`, and `accessedAt`
- document API difference for AccessLog

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total`
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total`


------
https://chatgpt.com/codex/tasks/task_e_685ac7f93c5c8320a309c8a0be3cf128