### PR TITLE
Fix local API port

### DIFF
--- a/config/start-functions.bat
+++ b/config/start-functions.bat
@@ -38,4 +38,5 @@ netstat -ano | findstr :7071 >nul
 if errorlevel 1 goto waitLoop
 
 :: ========= Frontend 起動 =========
+set API_URL=http://localhost:7071
 start "FRONT" cmd /k "cd /d %FRONT_DIR% && npm run dev"


### PR DESCRIPTION
## Summary
- set `API_URL` to the functions host before starting Next.js

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total`
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total`


------
https://chatgpt.com/codex/tasks/task_e_685b75ad60e48320826a468ea85381c7