### PR TITLE
Handle API PascalCase in search form

### DIFF
--- a/src/Presentation/components/PlaceSearchForm.tsx
+++ b/src/Presentation/components/PlaceSearchForm.tsx
@@ -37,9 +37,9 @@ export default function PlaceSearchForm({ onSelected }: Props) {
       const results = data.results ?? data.Results ?? [];
       if (Array.isArray(results)) {
         const normalized = results.map((r: any) => ({
-          place_id: r.place_id ?? r.placeId,
-          name: r.name,
-          description: r.description,
+          place_id: r.place_id ?? r.placeId ?? r.PlaceId,
+          name: r.name ?? r.Name,
+          description: r.description ?? r.Description,
         }));
         setSuggestions(normalized);
       } else {
@@ -55,12 +55,12 @@ export default function PlaceSearchForm({ onSelected }: Props) {
     if (resp.ok) {
       const detail = await resp.json();
       const normalized: PlaceDetails = {
-        place_id: detail.place_id ?? detail.placeId,
-        name: detail.name,
-        address: detail.address,
-        lat: detail.lat,
-        lng: detail.lng,
-        map_url: detail.map_url ?? detail.mapUrl,
+        place_id: detail.place_id ?? detail.placeId ?? detail.PlaceId,
+        name: detail.name ?? detail.Name,
+        address: detail.address ?? detail.Address,
+        lat: detail.lat ?? detail.Lat,
+        lng: detail.lng ?? detail.Lng,
+        map_url: detail.map_url ?? detail.mapUrl ?? detail.MapUrl,
       };
       onSelected(normalized);
     }


### PR DESCRIPTION
## Summary
- support snake_case/camelCase/PascalCase properties returned from `/api/map`

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total`
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685be0c4e41883209f3878ff197a3b6d