### PR TITLE
Fix API base URL in Presentation

### DIFF
--- a/src/Presentation/app/search/page.tsx
+++ b/src/Presentation/app/search/page.tsx
@@ -30,9 +30,9 @@ export default function SearchPage() {
       session_id: sessionIdRef.current,
       accessed_at: new Date().toISOString(),
     };
-    fetch('/api/log/access', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(log) });
-    fetch('/api/test-data/initialize', { method: 'POST' }).catch(() => {});
-    fetch('/api/test-data/seed', { method: 'POST' }).catch(() => {});
+    fetch(`${baseUrl}/api/log/access`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(log) });
+    fetch(`${baseUrl}/api/test-data/initialize`, { method: 'POST' }).catch(() => {});
+    fetch(`${baseUrl}/api/test-data/seed`, { method: 'POST' }).catch(() => {});
   }, []);
 
   return (

--- a/src/Presentation/components/PlaceSearchForm.tsx
+++ b/src/Presentation/components/PlaceSearchForm.tsx
@@ -21,6 +21,8 @@ interface PlaceDetails {
   map_url: string;
 }
 
+const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
+
 export default function PlaceSearchForm({ onSelected, sessionId }: Props) {
   const [query, setQuery] = useState('');
   const [suggestions, setSuggestions] = useState<SearchResultItem[]>([]);
@@ -32,7 +34,7 @@ export default function PlaceSearchForm({ onSelected, sessionId }: Props) {
       setSuggestions([]);
       return;
     }
-    const resp = await fetch(`/api/map?query=${encodeURIComponent(q)}`);
+    const resp = await fetch(`${baseUrl}/api/map?query=${encodeURIComponent(q)}`);
     if (resp.ok) {
       const data = await resp.json();
       const results = data.results ?? data.Results ?? [];
@@ -53,7 +55,7 @@ export default function PlaceSearchForm({ onSelected, sessionId }: Props) {
       action_name: 'search',
       actioned_at: new Date().toISOString(),
     };
-    fetch('/api/log/action', {
+    fetch(`${baseUrl}/api/log/action`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(actionLog),
@@ -63,7 +65,7 @@ export default function PlaceSearchForm({ onSelected, sessionId }: Props) {
   async function select(item: SearchResultItem) {
     setQuery(item.description);
     setSuggestions([]);
-    const resp = await fetch(`/api/map/${item.place_id}`);
+    const resp = await fetch(`${baseUrl}/api/map/${item.place_id}`);
     if (resp.ok) {
       const detail = await resp.json();
       const normalized: PlaceDetails = {
@@ -84,7 +86,7 @@ export default function PlaceSearchForm({ onSelected, sessionId }: Props) {
         lng: normalized.lng,
         searched_at: new Date().toISOString(),
       };
-      fetch('/api/log/search_result', {
+      fetch(`${baseUrl}/api/log/search_result`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(searchLog),


### PR DESCRIPTION
## Summary
- prefix API calls with configured base URL so static export works

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total`
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total`


------
https://chatgpt.com/codex/tasks/task_e_685beba7d0cc8320a6820abb036659d2