### PR TITLE
Improve search suggestions UX

### DIFF
--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -20,3 +20,6 @@
 - **レスポンシブ対応の不足**
   - 仕様のブレークポイントは `480px, 640px, 768px, 1024px, 1280px`【F:specification/ui-design.yaml†L27-L31】。
   - 実装の CSS では `480px` と `768px` のみ定義されている【F:src/Presentation/globals.css†L20-L25】。
+- **検索フォームの未定義挙動**
+  - 仕様では検索候補件数や空結果時のメッセージについて言及がない【F:specification/ui-design.yaml†L77-L81】。
+  - 実装では候補がない場合 `No results found.` と表示され、候補は1件のみだった【F:src/Presentation/components/PlaceSearchForm.tsx†L46-L54】。

--- a/src/Presentation/components/PlaceSearchForm.tsx
+++ b/src/Presentation/components/PlaceSearchForm.tsx
@@ -46,7 +46,7 @@ export default function PlaceSearchForm({ onSelected, sessionId }: Props) {
         const data = await resp.json();
         const results = data.results ?? data.Results ?? [];
         if (Array.isArray(results)) {
-          const normalized = results.map((r: any) => ({
+          const normalized = results.slice(0, 5).map((r: any) => ({
             place_id: r.place_id ?? r.placeId ?? r.PlaceId,
             name: r.name ?? r.Name,
             description: r.description ?? r.Description,
@@ -108,6 +108,7 @@ export default function PlaceSearchForm({ onSelected, sessionId }: Props) {
       aria-label="Search place"
       className="w-full"
       popoverProps={{ shouldBlockScroll: true }}
+      listboxProps={{ emptyContent: null, itemClasses: { base: 'cursor-pointer' } }}
       inputValue={query}
       onInputChange={handleChange}
       onSelectionChange={(key) => {


### PR DESCRIPTION
## Summary
- fix search suggestions to show up to 5 items
- hide "No results found" text and make items appear clickable
- document spec/impl differences for search form

## Testing
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total`
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total`


------
https://chatgpt.com/codex/tasks/task_e_685d0b7d27c4832097b04bd428f0b6e0