### PR TITLE
Fix search suggestions

### DIFF
--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -21,6 +21,6 @@
   - 仕様のブレークポイントは `480px, 640px, 768px, 1024px, 1280px`【F:specification/ui-design.yaml†L27-L31】。
   - 実装の CSS では `480px` と `768px` のみ定義されている【F:src/Presentation/globals.css†L20-L25】。
 - **検索フォームの未定義挙動**
-  - 仕様では検索候補件数や空結果時のメッセージについて言及がない【F:specification/ui-design.yaml†L77-L81】。
-  - 実装では候補がない場合 `No results found.` と表示され、候補は1件のみだった【F:src/Presentation/components/PlaceSearchForm.tsx†L46-L54】。
+  - 仕様では候補数は 5 件と定められているが、空結果時のメッセージは記載がない【F:specification/ui-design.yaml†L80-L86】。
+  - 実装では候補がない場合 `No results found.` と表示している【F:src/Presentation/components/PlaceSearchForm.tsx†L107-L124】。
 

--- a/src/Presentation/components/PlaceSearchForm.tsx
+++ b/src/Presentation/components/PlaceSearchForm.tsx
@@ -110,15 +110,16 @@ export default function PlaceSearchForm({ onSelected, sessionId }: Props) {
       popoverProps={{ shouldBlockScroll: true }}
       listboxProps={{ emptyContent: null, itemClasses: { base: 'cursor-pointer' } }}
       inputValue={query}
+      items={suggestions}
       onInputChange={handleChange}
       onSelectionChange={(key) => {
         const item = suggestions.find((s) => s.place_id === key);
         if (item) select(item);
       }}
     >
-      {suggestions.map((s) => (
-        <AutocompleteItem key={s.place_id}>{s.description}</AutocompleteItem>
-      ))}
+      {(item) => (
+        <AutocompleteItem key={item.place_id}>{item.description}</AutocompleteItem>
+      )}
     </Autocomplete>
   );
 }


### PR DESCRIPTION
## Summary
- fix `PlaceSearchForm` to pass items directly to `<Autocomplete>` so filtering works
- update docs/ai-review

## Testing
- `npx next lint`
- `npx next build`
- `npx next dev` *(fails: fetch failed)*
- `dotnet build astro-form2.sln -c Release`
- `dotnet format --verify-no-changes`
- `dotnet test astro-form2.sln --collect:"XPlat Code Coverage"`
- `coverlet ./src/Test/Application/bin/Release/net8.0/Application.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Application/Application.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-application.xml --threshold 70 --threshold-type line --threshold-stat total`
- `coverlet ./src/Test/Domain/bin/Release/net8.0/Domain.Tests.dll --target "dotnet" --targetargs "test ./src/Test/Domain/Domain.Tests.csproj -c Release --no-build" --format cobertura --output ./TestResults/coverage-domain.xml --threshold 70 --threshold-type line --threshold-stat total`

------
https://chatgpt.com/codex/tasks/task_e_685d438df5008320bc09a5ffef97adf0